### PR TITLE
feat: 添加缓存构建器和无限列表功能

### DIFF
--- a/packages/pure/src/cache/core.test.ts
+++ b/packages/pure/src/cache/core.test.ts
@@ -3,7 +3,6 @@ import { random, times } from 'lodash-es';
 import { strategy } from './strategy';
 import { cache } from '.';
 
-
 describe('[cache.core]', () => {
   const sleep = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
 
@@ -12,6 +11,16 @@ describe('[cache.core]', () => {
 
   it('default', () => {
     const cached = cache.core(rand);
+
+    expect(cached(1)).not.toBeUndefined();
+    expect(cached(1)).toBe(cached(1));
+    expect(cached(2)).toBe(cached(2));
+    expect(cached(1)).not.toBe(cached(2));
+  });
+
+  it('build', () => {
+    const stra = cache.build();
+    const cached = stra(rand);
 
     expect(cached(1)).not.toBeUndefined();
     expect(cached(1)).toBe(cached(1));

--- a/packages/pure/src/cache/index.ts
+++ b/packages/pure/src/cache/index.ts
@@ -1,9 +1,11 @@
-import { core } from './core';
+import { build, core } from './core';
 import { strategy } from './strategy';
 
 export const cache = {
   core,
+  build,
   preset: {
     strategy,
   },
 };
+

--- a/packages/pure/src/cache/strategy.ts
+++ b/packages/pure/src/cache/strategy.ts
@@ -1,5 +1,13 @@
 import { CacheStrategy } from './types';
 
+const once = (): CacheStrategy => {
+  return (key, ctx: Record<string, boolean>) => {
+    const hit = ctx[key];
+    ctx[key] = true; 
+    return { hit, ctx };
+  };
+};
+
 const expired = (time: number): CacheStrategy => {
   return (_, ctx: any) => {
     const hit = Date.now() > time;
@@ -43,7 +51,10 @@ const lru = (cap: number): CacheStrategy => {
   };
 };
 
+
+
 export const strategy = {
+  once,
   expired,
   duration,
   lru,

--- a/packages/pure/src/cache/types.ts
+++ b/packages/pure/src/cache/types.ts
@@ -1,8 +1,7 @@
+import { Fn } from '../types';
 
-export type FnType = (...args: any[]) => any;
-
-export interface CacheSettings<Fn extends FnType> {
-  key: (params: Parameters<Fn>) => string;
+export interface CacheSettings<F extends Fn> {
+  key: (params: Parameters<F>) => string;
   strategy: CacheStrategy;
 }
 
@@ -17,8 +16,8 @@ export interface CacheStrategyResult {
   ctx: any;
 }
 
-export type FnSettings<Fn extends FnType> = {
-  [K in keyof CacheSettings<Fn>]: (setting: CacheSettings<Fn>[K]) => CachedFn<Fn>;
+export type FnSettings<F extends Fn> = {
+  [K in keyof CacheSettings<F>]: (setting: CacheSettings<F>[K]) => CachedFn<F>;
 };
 
-export type CachedFn<Fn extends FnType> = Fn & FnSettings<Fn>;
+export type CachedFn<F extends Fn> = F & FnSettings<F>;

--- a/packages/pure/src/functions/infinity.test.ts
+++ b/packages/pure/src/functions/infinity.test.ts
@@ -1,0 +1,78 @@
+
+import { describe, expect, it } from 'vitest';
+import { times } from 'lodash-es';
+import { hash } from '../mock/hash';
+import { either } from './either';
+import { infinity } from './infinity';
+
+interface User {
+  id: string;
+  name: string;
+  gender: 'male' | 'female';
+}
+
+type Filterify<T> = {
+  [K in keyof T]?: T[K][];
+}
+
+interface ListRequest<T> {
+  filter?: Filterify<T>;
+  page?: {
+    size?: number;
+    index?: number;
+  }
+}
+
+interface ListResponse<T> {
+  items: T[];
+  page: {
+    size: number;
+    index: number;
+    total: number;
+  }
+}
+
+const listUsers = async (req: ListRequest<User>): Promise<ListResponse<User>> => {
+  const totalCount = hash.number(req.filter, 256);
+  const { size = 10, index = 1 } = req.page ?? {};
+  const count = Math.min(totalCount - size * (index - 1), size);
+  
+  const items = times(count, (i): User => {
+    return {
+      id: '' + (size * (index - 1) + i + 1),
+      name: hash.string(size * (index - 1) + i + 1),
+      gender: hash.boolean(size * (index - 1) + i + 1) ? 'male' : 'female',
+    };
+  });
+
+  return {
+    items,
+    page: {
+      size,
+      index,
+      total: totalCount,
+    },
+  };
+};
+
+describe('[infinity]', () => {
+  it('normal', async () => {
+    const infinityListUsers = infinity.preset.normal(
+      (filter: ListRequest<User>['filter']) => 
+        listUsers({ 
+          filter, 
+          page: { size: 1, index: 1 },
+        })
+          .then(({ page: { size, index, total } }) => [index, size, total]),
+      ([index, size], filter) => 
+        listUsers({ 
+          filter, 
+          page: { index, size }, 
+        }).then(r => r.items),
+    );
+    const checkResp = await listUsers({ filter: { gender: ['male'] }, page: { size: 1, index: 1 } });
+    const users = await infinityListUsers({ gender: ['male'] });
+
+    expect(users.length).toEqual(checkResp.page.total);
+  });
+});

--- a/packages/pure/src/functions/infinity.ts
+++ b/packages/pure/src/functions/infinity.ts
@@ -1,0 +1,28 @@
+interface InfinityOptions<P> {
+  next: (p: P) => P;
+  end: (p: P) => boolean;
+}
+
+export const infinity = <P>(options: InfinityOptions<P>) => {
+  return <E, T>(init: (extra?: E) => Promise<P>, fn: (p: P, extra?: E) => Promise<T[]>) => {
+    return async (extra?: E): Promise<T[]> => {
+      const { next, end } = options;
+      let p: P = await init(extra);
+      const result: T[] = [];
+      while (!end(p)) {
+        const data: T[] = await fn(p, extra);
+        result.push(...data);
+        p = next(p);
+      }
+      return result;
+    };
+  };
+};
+
+type Page = [number, number, number];
+infinity.preset = {
+  normal: infinity({
+    next: ([idx, size, total]: Page): Page => [idx + 1, size, total],
+    end: ([idx, size, total]) => (idx - 1) * size >= total,
+  }),
+};

--- a/packages/pure/src/mock/hash.ts
+++ b/packages/pure/src/mock/hash.ts
@@ -1,0 +1,23 @@
+import { isString, upperFirst } from 'lodash-es';
+import { unwrap } from '../functions';
+
+export const hash = {
+  _: (x: any) => {
+    const str = isString(x)
+      ? x
+      : unwrap(() => JSON.stringify(x)) ?? '';
+    return str.split('');
+  },
+  number: (x: any, limit = 65535) => {
+    return hash._(x).reduce((acc, cur) => {
+      return (acc + cur.charCodeAt(0)) % limit + 1;
+    }, 0);
+  },
+  boolean: (x: any) => {
+    return !!hash.number(x, 2);
+  },
+  string: (x: any, length = 6) => {
+    const str = hash._(x).slice(0, length);
+    return upperFirst(str.join(''));
+  },
+};

--- a/packages/pure/src/path/index.ts
+++ b/packages/pure/src/path/index.ts
@@ -80,7 +80,6 @@ export const path = {
   sdk: {
     core: createPathSdk,
     preset: {
-      
     },
   },
 };

--- a/packages/pure/src/types.ts
+++ b/packages/pure/src/types.ts
@@ -1,1 +1,3 @@
 export type MaybePromise<T> = T | Promise<T>;
+
+export type Fn<R = any> = (...args: any[]) => R;


### PR DESCRIPTION
添加缓存构建器函数`build`以支持链式配置缓存策略
新增`infinity`函数用于处理分页数据的无限加载
在`types.ts`中统一函数类型定义`Fn`
添加`hash`工具函数用于模拟数据生成