### PR TITLE
ci: add beta release workflow

### DIFF
--- a/.github/workflows/beta-release.yml
+++ b/.github/workflows/beta-release.yml
@@ -1,0 +1,49 @@
+name: Beta Release
+
+on:
+  push:
+    branches:
+      - 'release/**'
+
+concurrency:
+  group: beta-release-${{ github.ref_name }}
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  id-token: write
+
+jobs:
+  publish-beta:
+    name: Publish beta package
+    runs-on: ubuntu-latest
+    if: github.actor != 'github-actions[bot]'
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          registry-url: https://registry.npmjs.org
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Configure npm token fallback
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          if [ -n "$NPM_TOKEN" ]; then
+            echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > ~/.npmrc
+          fi
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Publish beta
+        run: node scripts/beta-release.mjs

--- a/scripts/beta-release.mjs
+++ b/scripts/beta-release.mjs
@@ -1,0 +1,149 @@
+import { execFileSync } from 'node:child_process';
+import { existsSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+const dryRun = process.env.BETA_RELEASE_DRY_RUN === '1';
+const root = execFileSync('git', ['rev-parse', '--show-toplevel'], {
+  encoding: 'utf8',
+  stdio: ['ignore', 'pipe', 'inherit'],
+}).trim();
+const branch = process.env.GITHUB_REF_NAME ?? exec('git', ['rev-parse', '--abbrev-ref', 'HEAD']).trim();
+const match = branch.match(/^release\/(.+)\/(\d+\.\d+\.\d+)$/);
+if (!match) {
+  throw new Error(`Branch must match release/<package-path>/x.y.z, got ${branch}`);
+}
+
+const [, rawPackagePath, baseVersion] = match;
+const packagePath = rawPackagePath.replace(/^packages\//, '');
+if (packagePath.includes('..') || path.isAbsolute(packagePath)) {
+  throw new Error(`Invalid package path in branch: ${rawPackagePath}`);
+}
+
+const packageDir = path.join(root, 'packages', packagePath);
+const packageJsonPath = path.join(packageDir, 'package.json');
+if (!existsSync(packageJsonPath)) {
+  throw new Error(`No package.json found at ${packageJsonPath}`);
+}
+
+const packageJson = readPackageJson();
+const packageName = packageJson.name;
+if (!packageName) {
+  throw new Error(`${packageJsonPath} is missing name`);
+}
+
+setBaseVersion();
+run('pnpm', ['--filter', packageName, 'build']);
+
+const betaVersion = prepareBetaVersion();
+const tarball = packPackage();
+publishTarball(tarball);
+tagBetaRelease(betaVersion);
+console.log(`Published ${packageName}@${betaVersion}`);
+
+function setBaseVersion() {
+  if (packageJson.version === baseVersion) {
+    return;
+  }
+  packageJson.version = baseVersion;
+  writePackageJson(packageJson);
+  run('git', ['config', 'user.name', 'github-actions[bot]']);
+  run('git', ['config', 'user.email', '41898282+github-actions[bot]@users.noreply.github.com']);
+  run('git', ['add', packageJsonPath]);
+  run('git', ['commit', '-m', `chore(${packagePath}): set release version ${baseVersion} [skip ci]`]);
+  run('git', ['push']);
+}
+
+function prepareBetaVersion() {
+  if (hasPublishedVersion(`${baseVersion}-beta.0`)) {
+    const latestBeta = latestPublishedBeta();
+    run('npm', ['version', latestBeta, '--no-git-tag-version'], { cwd: packageDir });
+    run('npm', ['version', 'prerelease', '--no-git-tag-version'], { cwd: packageDir });
+  }
+  else {
+    run('npm', ['version', `${baseVersion}-beta.0`, '--no-git-tag-version'], { cwd: packageDir });
+  }
+  return readPackageJson().version;
+}
+
+function latestPublishedBeta() {
+  const versions = npmView([packageName, 'versions', '--json'], '[]');
+  const parsed = JSON.parse(versions);
+  const prefix = `${baseVersion}-beta.`;
+  const betaVersions = parsed
+    .filter(version => version.startsWith(prefix))
+    .sort((left, right) => betaNumber(left) - betaNumber(right));
+  if (betaVersions.length === 0) {
+    throw new Error(`Expected ${packageName}@${baseVersion}-beta.0 to exist`);
+  }
+
+  return betaVersions.at(-1);
+}
+
+function betaNumber(version) {
+  return Number(version.slice(`${baseVersion}-beta.`.length));
+}
+
+function hasPublishedVersion(version) {
+  try {
+    npmView([`${packageName}@${version}`, 'version'], undefined, { silent: true });
+    return true;
+  }
+  catch {
+    return false;
+  }
+}
+
+function tagBetaRelease(version) {
+  const tag = `${packageName}@${version}`;
+  run('git', ['tag', tag]);
+  run('git', ['push', 'origin', tag]);
+}
+
+function packPackage() {
+  const packDir = mkdtempSync(path.join(os.tmpdir(), 'sokutils-beta-'));
+  const output = run('pnpm', ['pack', '--pack-destination', packDir, '--json'], {
+    cwd: packageDir,
+  });
+  return JSON.parse(output).filename;
+}
+
+function publishTarball(tarball) {
+  run('npm', ['publish', tarball, '--tag', 'beta', '--access', 'public', '--provenance', '--ignore-scripts']);
+}
+
+function readPackageJson() {
+  return JSON.parse(readFileSync(packageJsonPath, 'utf8'));
+}
+
+function writePackageJson(value) {
+  writeFileSync(packageJsonPath, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+function npmView(args, fallback, options = {}) {
+  try {
+    return exec('npm', ['view', ...args], options).trim();
+  }
+  catch (error) {
+    if (fallback !== undefined) {
+      return fallback;
+    }
+    throw error;
+  }
+}
+
+function run(command, args, options = {}) {
+  console.log(`$ ${[command, ...args].join(' ')}`);
+  if (dryRun && ['add', 'commit', 'push', 'publish', 'tag'].some(commandName => args.includes(commandName))) {
+    return '';
+  }
+  return exec(command, args, options);
+}
+
+function exec(command, args, options = {}) {
+  return execFileSync(command, args, {
+    cwd: options.cwd ?? root,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', options.silent ? 'ignore' : 'inherit'],
+  });
+}


### PR DESCRIPTION
## Summary
- add a beta release workflow for release/**/x.y.z branches
- derive the target package and base version from the branch name
- commit only the base x.y.z version back to the release branch
- publish temporary x.y.z-beta.N packages without committing prerelease versions
- publish with npm dist-tag beta and create package@version git tags

## Verification
- node --check scripts/beta-release.mjs
- BETA_RELEASE_DRY_RUN=1 GITHUB_REF_NAME=release/packages/pure/1.0.1 node scripts/beta-release.mjs
- mocked existing beta flow increments 1.0.1-beta.2 to 1.0.1-beta.3 via npm version prerelease
- pnpm --filter @sokutils/pure test
- pnpm --filter @sokutils/react build