### PR TITLE
ci: add stable release workflow

### DIFF
--- a/.github/workflows/stable-release.yml
+++ b/.github/workflows/stable-release.yml
@@ -1,0 +1,56 @@
+name: Stable Release
+
+on:
+  pull_request:
+    types:
+      - closed
+    branches:
+      - main
+
+concurrency:
+  group: stable-release-${{ github.event.pull_request.head.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  id-token: write
+
+jobs:
+  publish-stable:
+    name: Publish stable package
+    runs-on: ubuntu-latest
+    if: >-
+      github.event.pull_request.merged == true &&
+      startsWith(github.event.pull_request.head.ref, 'release/')
+
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          registry-url: https://registry.npmjs.org
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Configure npm token fallback
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          if [ -n "$NPM_TOKEN" ]; then
+            echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > ~/.npmrc
+          fi
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Publish stable
+        env:
+          RELEASE_BRANCH: ${{ github.event.pull_request.head.ref }}
+        run: node scripts/stable-release.mjs

--- a/scripts/stable-release.mjs
+++ b/scripts/stable-release.mjs
@@ -1,0 +1,125 @@
+import { execFileSync } from 'node:child_process';
+import { existsSync, mkdtempSync, readFileSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+const dryRun = process.env.STABLE_RELEASE_DRY_RUN === '1';
+const root = execFileSync('git', ['rev-parse', '--show-toplevel'], {
+  encoding: 'utf8',
+  stdio: ['ignore', 'pipe', 'inherit'],
+}).trim();
+const branch = process.env.RELEASE_BRANCH ?? process.env.GITHUB_HEAD_REF ?? '';
+const match = branch.match(/^release\/(.+)\/(\d+\.\d+\.\d+)$/);
+if (!match) {
+  throw new Error(`Release branch must match release/<package-path>/x.y.z, got ${branch}`);
+}
+
+const [, rawPackagePath, version] = match;
+const packagePath = rawPackagePath.replace(/^packages\//, '');
+if (packagePath.includes('..') || path.isAbsolute(packagePath)) {
+  throw new Error(`Invalid package path in branch: ${rawPackagePath}`);
+}
+
+const packageDir = path.join(root, 'packages', packagePath);
+const packageJsonPath = path.join(packageDir, 'package.json');
+if (!existsSync(packageJsonPath)) {
+  throw new Error(`No package.json found at ${packageJsonPath}`);
+}
+
+const packageJson = readPackageJson();
+const packageName = packageJson.name;
+if (!packageName) {
+  throw new Error(`${packageJsonPath} is missing name`);
+}
+if (packageJson.version !== version) {
+  throw new Error(`${packageName} version is ${packageJson.version}; expected ${version} from ${branch}`);
+}
+
+run('pnpm', ['--filter', packageName, 'build']);
+
+if (hasPublishedVersion(version)) {
+  console.log(`${packageName}@${version} is already published; skipping npm publish.`);
+  tagStableRelease(version);
+  process.exit(0);
+}
+
+const tarball = packPackage();
+publishTarball(tarball);
+tagStableRelease(version);
+console.log(`Published ${packageName}@${version}`);
+
+function hasPublishedVersion(targetVersion) {
+  try {
+    npmView([`${packageName}@${targetVersion}`, 'version'], undefined, { silent: true });
+    return true;
+  }
+  catch {
+    return false;
+  }
+}
+
+function tagStableRelease(targetVersion) {
+  const tag = `${packageName}@${targetVersion}`;
+  if (tagExists(tag)) {
+    console.log(`Tag ${tag} already exists; skipping git tag.`);
+    return;
+  }
+  run('git', ['config', 'user.name', 'github-actions[bot]']);
+  run('git', ['config', 'user.email', '41898282+github-actions[bot]@users.noreply.github.com']);
+  run('git', ['tag', tag]);
+  run('git', ['push', 'origin', tag]);
+}
+
+function tagExists(tag) {
+  try {
+    exec('git', ['rev-parse', '--verify', `refs/tags/${tag}`], { silent: true });
+    return true;
+  }
+  catch {
+    return false;
+  }
+}
+
+function packPackage() {
+  const packDir = mkdtempSync(path.join(os.tmpdir(), 'sokutils-stable-'));
+  const output = run('pnpm', ['pack', '--pack-destination', packDir, '--json'], {
+    cwd: packageDir,
+  });
+  return JSON.parse(output).filename;
+}
+
+function publishTarball(tarball) {
+  run('npm', ['publish', tarball, '--tag', 'latest', '--access', 'public', '--provenance', '--ignore-scripts']);
+}
+
+function readPackageJson() {
+  return JSON.parse(readFileSync(packageJsonPath, 'utf8'));
+}
+
+function npmView(args, fallback, options = {}) {
+  try {
+    return exec('npm', ['view', ...args], options).trim();
+  }
+  catch (error) {
+    if (fallback !== undefined) {
+      return fallback;
+    }
+    throw error;
+  }
+}
+
+function run(command, args, options = {}) {
+  console.log(`$ ${[command, ...args].join(' ')}`);
+  if (dryRun && ['publish', 'push', 'tag'].some(commandName => args.includes(commandName))) {
+    return '';
+  }
+  return exec(command, args, options);
+}
+
+function exec(command, args, options = {}) {
+  return execFileSync(command, args, {
+    cwd: options.cwd ?? root,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', options.silent ? 'ignore' : 'inherit'],
+  });
+}


### PR DESCRIPTION
## Summary
- add stable release workflow triggered when release/**/x.y.z PRs are merged into main
- parse package path and target x.y.z from the merged branch name
- verify the merged package.json version matches x.y.z before publishing
- publish packed artifact to npm latest with provenance
- create package@x.y.z git tag, with idempotent handling for reruns

## Verification
- node --check scripts/stable-release.mjs
- ruby YAML parse for .github/workflows/stable-release.yml
- STABLE_RELEASE_DRY_RUN=1 RELEASE_BRANCH=release/pure/1.0.0 node scripts/stable-release.mjs
- STABLE_RELEASE_DRY_RUN=1 RELEASE_BRANCH=release/packages/pure/1.0.1 node scripts/stable-release.mjs after temporary version bump
- mismatch branch/version failure check
- pnpm --filter @sokutils/pure test
- pnpm --filter @sokutils/react build